### PR TITLE
BHA proofreading batch: banned-historical-archives2:ocr_patch

### DIFF
--- a/[0530a4cc57][5382c50c-a47e-4f7f-bb62-396b1033f322].ts
+++ b/[0530a4cc57][5382c50c-a47e-4f7f-bb62-396b1033f322].ts
@@ -1,0 +1,3 @@
+export default [
+  {"comments": {}, "description": "", "parts": {"2": {"diff": "-42\t=12"}}, "version": 2},
+];


### PR DESCRIPTION
<!-- proofreading-upstream-batch -->
<!-- proofreading-prs:[{"repo":"banned-historical-archives2","number":1,"url":"https://github.com/anftm/banned-historical-archives2/pull/1"}] -->
此 PR 汇总已在 anftm fork 审核并合并的 BHA 校订。

来源校订 PR：
- [x] [banned-historical-archives2#1](https://github.com/anftm/banned-historical-archives2/pull/1)

目标仓库：`banned-historical-archives/banned-historical-archives2`
目标分支：`ocr_patch`

请在目标仓库审核后使用 merge commit 合并；不要使用 squash 或 rebase，以便 fork 后续安全快进同步。

## 来源 PR：[banned-historical-archives2#1](https://github.com/anftm/banned-historical-archives2/pull/1)

## 校订

- Archive：`banned-historical-archives2`
- Article ID：`0530a4cc57`
- 文章：从资产阶级民主派到走资派
- 修改：正文段落 1 处

## 修改内容

- 段落 3：594?4c:0C\+4\+040re4:04\*/4:0ny04:\*:04?t00\+00从资产阶级民主派到走资派 → 从资产阶级民主派到走资派

## 原全文

```text
批判修正主义路线
回击右倾翻案风
594?4c:0C+4+040re4:04*/4:0ny04:*:04?t00+00从资产阶级民主派到走资派
池
恒
伟大领袖毛主席亲自发动和领导的回击右倾翻案风的伟大斗争，正在教育、科技，文艺等上层建筑的各个领域健康地发展，批判的锋芒，直指提出“三项指示为纲”那个党内不肯改悔的走资本主义道路的当权派。这是无产阶级文化大革命的继续和深入，是政治思想战线上无产阶级和资产阶级、社会主义和资本主义、马克思主义和修正主义的又一次大较量。认真地学习毛主席的重要指示，坚决击退这股右倾翻案风，深入地批判那条同毛主席革命路线相对抗的修正主义路线，批判“三项指示为纲”的修正主义纲领，使这场斗争取得更大的胜利，这是摆在全党同志和全国人民面前的一件大事。经过这场斗争，我们的广大干部和群众，必将受到一次深刻的马克思主义、列宁主义、毛泽东思想的教育，进一步提高阶级斗争和路线斗争的觉悟；我国的社会主义革命和建设事业，必将大大地向前推进一步。
革命大辩论的深入发展，向人们提出了一些发人深省的问题：为什么有的人在新民主主义革命时期革过别人的命，到了社会主义革命时期总是同革命唱反调，成了走资本主义道路的当权派？为什么有的走资派受到文化大革命的批判之后，发誓“永不翻案”，可是重新工作没多久就大刮右倾翻案风，对文化大革命又是翻案又是算帐，成了不肯改悔的走资派？为什么不肯改悔的走资派要否认社会主义社会的阶级、阶级矛盾和阶级斗争，反对以阶级斗争为纲，公然抛出“三项指示为纲”的修正主义纲领，同毛主席为我们党制定的基本路线相对抗？针对这些问题，用马克思主义、列宁主义、毛泽东思想作指导，运用阶级分析的方法来部析党内不肯改悔的走资派的阶级立场和世界观，就可以找到这股右倾翻案风的阶级根源和思想根源，可以更好地发挥反面教员的作用，使我们从中得到有益的教训。
一九五九年，毛主席在党的八届八中全会上曾经深刻地指出，党内的右倾机会主义分子从来不是无产阶级革命家，只不过是跑到无产阶级革命队伍里来的资产阶级，小资产阶级的民主派；他们从来不是马克思列宁主义者，只不过是党的同路人。党内不肯改悔的走资派，也正是这样一种人。他们是带着资产阶级民主主义思想来参加无产阶级革命队伍的，他们在组织上入了党，思想上并没有完全入党，甚至完全没有入党。他们在程度不同地接受党的最低纲领即新民主主义革命纲领时，并没有把它同党的最高纲领即社会主义、共产主义的纲领联系起来，他们不懂得也不准备去实践党的最高纲领。也就是说，他们的世界观并不是无产阶级的共产主义世界观，而是一个资产阶级的王国。这种资产阶级立场，世界观又没有在长期的革命斗争中得到改造；当革命从新民主主义革命阶段向社会主义革命阶段转变的时候，他们的思想并没有随着革命的转变而转变。相反，他们的身子虽然进了社会主义社会，思想却还停止在民主革命阶段，这就决定了他们对社会主义革命必然产生抵触甚至反对。资产阶级民主派的立场和世界观，代表资产阶级，就是右倾翻案风的阶级根源和思想根源。
我们党领导的新民主主义革命和社会主义革命，是性质，对象，任务都有本质区别的两个革命阶段。前者发生在半殖民地半封建社会的旧中国，它要解决的主要矛盾，是包括工人、农民，小资产阶级，民族资产阶级在内的人民大众，同帝国主义，封建主义、官僚资本主义的矛盾。所以它的性质是反帝反封建的资产阶级民主革命，它的任务，是在无产阶级领导下，推翻帝国主义、封建地主阶级和官僚买办资产阶级在中国的统治，把革命引向社会主义。随着新民主主义革命的胜利，我国的社会性质和主要矛盾已经发生变化。无产阶级同资产阶级的矛盾成了国内的主要矛盾。这个主要矛盾，不仅存在于社会上，面且反映到党内。我们所进行的社会主义革命，就是无产阶级反对资产阶级和一切剥削阶级的革命。革命的锋芒主要是指向资产阶级，指向党内走资本主义道路的当权派。它的任务是要用无产阶级专政代替资产阶级专政，用社会主义战胜资本主义，并在长期的阶级斗争中逐步造成资产阶级既不能存在又不能产生的条件，最后消灭阶级，实现共产主义。一九四九年中华人民共和国成立，标志着社会主义革命阶段的开始。在毛主席革命路线的指引下，二十多年来，社会主义革命已经取得了伟大的胜利，但是还远远没有完结，还在继续深入发展。革命转变了，向前发展了，要求人们的思想也要随着革命的转变而转变，随着革命的发展而发展。如果思想还停止在旧阶段，用资产阶级民主派的立场和世界观来认识和对待社会主义革命，那就会代表资产阶级，就会成为走资派，成为社会主义革命的对象。
我国新民主主义革命胜利以后，在毛主席革命路线的指引下，广大工人、贫下中农，广大党员、干部没有停顿，而是沿着社会主义道路继续前进。但是党内有一些人的思想还停止在民主革命阶段，不想沿着社会主义道路继续前进，继续革命了。不前进，就会倒退，不革命，就会搞复辟，不走社会主义道路，必然要走资本主义道路。列宁曾经指出：“有些人象小私有者一样看待对资本家的胜利，他们说：‘资本家已经捞了一把，现在该轮到我了。’”党内不肯改悔的走资派不也是这样吗？他们害怕社会主义革命革到自已头上，触动私有制，触动他们所喜欢的资产阶级法权，触动他们要维护的传统观念，触动他们的资产阶级立场和世界观，成了资产阶级的代表。社会主义革命越深入，他们同革命的矛盾，同坚持继续革命的工人，贫下中农的矛盾，也就越尖锐。在社会主义革命的进程中，他们后退了，反对革命了。就是那个作为右倾翻案风“风源”的不肯改悔的走资派，曾经反对农业合作化和人民公社化，支持包产到户，鼓吹“不管白猫黑猫，捉住老鼠就是好猫”的谬论，后来又反对文化大革命，镇压革命群众运动，现在文闹翻案、搞复辟。从资产阶级民主派到走资本主义道路的当权派，从民主革命时期党的同路人到社会主义时期的反对派，复辟派，从思想停上在资产阶级民主革命阶段到搞修正主义，这不正是不肯改悔的走资涨所实际走过的道路吗？
历史的经验和现实的斗争都说明，在社会主义革命时期，思想还停止在资产阶级民主革命阶段，就会搞修正主义，推行修正主义路线。毛主席指出：“修正主义是一种资产阶级思想。修正主义者抹杀社会主义和资本主义的区别，抹杀无产阶级专致和资产阶级专政的区别。他们所主张的，在实际上并不是社会主义路线，而是资本主义路线。”从思想体系和阶级根源来看，资产阶级的立场，世界观和修正主义是一致的。机会主义，修正主义是工人运动中代表资产阶级利益的派别和思想，它的特征是叛卖无产阶级的根本利益，向资产阶级投降。修正主义者总是站在资产阶级立场上，鼓吹阶级调和论，阶级斗争熄灭论和唯生产力论，总是用这些修正主义谬论，来反对无产阶级对资产阶级的阶级斗争，反对无产阶级专政。从伯恩施坦、考茨基到托洛茨基、布哈林，从赫鲁晓夫、勃列日涅夫到刘少奇、林彪，都是这么干的。党内不肯改悔的走资派，也是这样。他迫不及待地抛出“三项指示为纲”的修正主义纲领，鼓吹阶级斗争熄灭论和唯生产力论，以此来否定党的基本路线，同马克思主义，列宁主义、毛泽东思想关于阶级斗争和无产阶级专政的理论相对抗；并用它来于扰，破坏毛主席亲自发动和领导的无产阶级专政理论的学习运动和评论《水浒》；用它在各个领域推行修正主义路线。去年在教育，科技、文艺以及其他战线出现的反对毛主席革命路线，反对文化大革命和社会主义新生事物的各种奇谈怪论，就是根据“三项指示为纲”这个修正主义纲领派生出来的。思想停止在民主革命阶段，否认社会主义时期的阶级，阶级矛盾和阶级斗争，就必然要搞修正主义。党内不肯改悔的走资派刮起的右倾翻案风，又一次说明了这一点。
毛主席说：“杆么‘三项指示为纲”，安定团绪不是不要阶级斗争，阶级斗争是纳，其余舞是目。”这是对“三项指示为纲”的修正主义纲领的深刻批判。二十多年来，我们所进行的社会主义革命已经取得了伟大的胜利，但是，阶级斗争并没有熄灭。失败的阶级，人还在，阶级还在，还要挣扎，时刻梦想着复辟，资产阶级和小资产阶级还存在，大量未改造好的知识分子还存在；小生产的习惯势力和传统影响还存在，还在产生资产阶级和资本主义。所有这些不是人们都看见了的事实吗：资产阶级在党内的代理人，刘少奇，林彪反党集团妄图颠覆无产阶级专政、复辟资本主义的阴谋活动，不是使人们感到惊心动魄吗！林彪一类党内新的资产阶级分子的产生，不是给我们以深刻的教育吗！清华大学的同志说得好：走资派还在走，投降派确实有。在这种情况下，能说阶级斗争熄灭了吗？党内不肯改悔的走资派抛出“三项指示为纲”，鼓吹阶级斗争熄灭论和唯生产力论，并不是要真正熄灭阶级斗争，他们是要扑灾无产阶级对资产阶级的斗争，而代表资产阶级向无产阶级进行斗争。他们要安定团结、发展生产是假，不要无产阶级专政，而要资本主义复辟才是真的。他们的修正主义路线是破坏安定团结，破坏社会主义生产的。这就从反面告诉我们，必须坚持以阶级斗争为纲，从政治、经济、思想文化各个方面，加强无产阶级对资产阶级的全面专政，不断地把社会主义革命推向前进。
民主革命胜利以后，是把革命停止在旧阶段不再前进，还是坚持搞社会主义革命，为最终实现共产主义而奋斗，也就是说要不要坚持不解地革资产阶级的命，这是无产阶级革命派和资产阶级民主派、马克思主义者和修正主义者的一个根本分歧。社会主义时期党内两条路线的斗争，正是围绕着这个问题展开的。修正主义路线的头子因为他们自己代表资产阶级，都反对革资产阶级的命，特别反对革党内资产阶级的命。党内不肯改悔的走资派为什么对文化大革命那么反感？为什么把文化大革命中涌现出来的社会主义新生事物，看成眼中钉、肉中刺，于方百计地想把它们“整”掉，而对文化大革命批判过的资本主义、修正主义的黑货，又那么舍不得，总想把它们恢复过来？就是因为“无产阶级文化大革命，实质上是在社会主义条件下，无产阶级反对资产阶级和一切剥削阶级的政治大革命”，这场大革命摧毁了刘少奇、林彪两个资产阶级司令部，批判了他们的修正主义路线，整了党内走资派，革了党内资产阶级的命，批判了资产阶级和一切剥削阶级的意识形态，对不适应社会主义经济基础的教育、文艺及其他上层建筑进行了改革。所有这些，同党内不肯改梅的走资派所代表的资产阶级利益，所顽固坚持的资产阶级立场和世界观是相对抗的，同他们极力要走的那条资本主义道路是背道而驰的。这就决定了他们必然要充当无产阶级文化大革命的反对派。人们还清楚地记得，就是那个带头刮右倾翻案风的人，在文化大革命初期，同刘少奇一起推行资产阶级反动路线，企图把轰轰烈烈的革命群众运动镇压下去。然而，这种倒行逆施并没有能够扭转革命车轮的前进，文化大革命和批林批孔运动取得了伟大的胜利。但不肯改悔的走资派并没有从中吸取教训，仍然代表资产阶级，用修正主义的眼光来看待这场大革命，把文化大革命以后的大好形势看成一团漆黑，总认为这也不行，那也不好，不翻案，不复辟就不舒服。“只要人家说你复辟了，你的工作就于好了”。这个自白把不肯改悔的走资派代表资产阶级搞复辟的反动立场暴露得清清楚楚了。他们的这次表演，又一次证明了毛主席的英明论断：革命的谁胜谁负，要在一个很长的历史时期内才能解决。如果弄得不好，资本主义复辟将是随时可能的。全体党员，全国人民，不要以为有一二次，三四次文化大革命，就可以太平无事了。千万注就，决不可丧失惕。
要把社会主义革命推向前进，就要在无产阶级专政下，对社会主义社会各方面存在的资产阶级法权加以限制。这也是思想停止在民主革命阶段的人不能接受而要加以反对的。社会生义社会还存在旧社会遗留下来的痕迹，存在着资产阶级法权，存在着三大差别。这些东西是产生资产阶级和资本主义的土壤和条件。限制资产阶级法权，逐步地铲除和消灭旧社会遗留下来的痕迹，这是社会主义时期一项长期的任务。社会主义革命越深入，就越要把这个任务提出来，越要着手这方面的工作。毛主席指出：“我国现在实行的是商品制度，工资制度也不平等，有八级工资制，等等。这只能在无产阶级专政下加以限制。所以，林彪一类如上台，搞资本主义制度很容易。因此，要多看点马列主义的书。”毛主席的指示反映了无产阶级和革命人民要把社会主义革命推向前进的愿望和要求，也引起了思想停止在民主革命阶段的人的害怕和抵触。资产阶级法权正是那些要阻止革命前进的人的命根子，他们所欣赏，所追求的就是这一块资产阶级法权，他们总是把资产阶级法权看成天经地义、不能触动的，总想把它强化和扩大。当革命革到这些人的头上，要求限制他们维护的那部分资产阶级法权时，他们就要跳出来反对。不肯改悔的走资派为什么那样仇视从各个方面限制了资产阶级法权的新生事物？为什么对批判物质刺激、知识私有等资产阶级法权思想提出种种责难？为什么那样害怕提出限制资产阶级法权的问题，并千方百计加以反对？为什么竟然明自张胆地同毛主席的指示唱反调，胡说“限制资产阶级法权，也要有一个物质基础，没有，怎么限制？”就是因为他代表资产阶级，他要维护并强化资产阶级法权，维护并扩大资产阶级赖以产生和存在的基础。这就进一步暴露了不肯改悔的走资派的资产阶级立场和世界观
由于思想停止在民主革命阶段，因而同社会主义革命相抵触甚至相反对，这是二十多年来我们党内反复出现的一种历史现象。例如，一九五三年我们党决定实行统购统销政策，这是进行社会主义革命和社会主义建设的一个重要步骤。当时党内就有人跳出来坚决反对，他们虽然顶着共产党员的称号，却成了城乡资本主义势力反对社会主义革命的代言人。在农业合作化时期，刘少奇一伙大批砍掉合作社，而后文当算帐派，刮起一阵所谓合作社没有优越性的小台风。他们为什么会逆社会主义革命的伟大潮流而动呢？他们想的做的为什么同儿亿农民想的做的，是如此不同甚至相反呢？根本问题就是他们的思想还停止在民主革命阶段，他们总是站在资产阶级立场上为少数人服务。正象毛主席所指出的：“他们老是站在资产阶级、1农、或者具有资本主义自发倾向的富裕中农的立场上替较少的人打主意，而没有站在工人阶级的立场上替整个国家和全体人民打主意。”又如，一九五七年资产阶级右派利用党的整风，向无产阶级发动猖狂进攻的时候，党内也有人主张资产阶级的纲领。他们同社会上的资产阶级右派互相呼应，要求实行资产阶级的“民主”“自由”和“平等”，反对党的领导，尤其反对党对教育、科学的领导，鼓欧什么“外行不能领导内行”，“教授治校”等口号。他们实际上是主张走资本主义道路，反对走社会主义道路，反对无产阶级专政。一九五九年彭德怀右倾机会主义反对党的总路线，否定大跃进和人民公社，再一次暴露了一些人的资产阶级民主派的本来面目。他们要在社会主义革命时期推行资本主义的纲领和口号，这就不能不被社会主义革命的潮流所淘汰。
在社会主义革命时期，共产党内还会有一些人思想停止在民主革命阶段，用资产阶级的立场、世界观看待事物，这种现象并不奇怪。我们的党是伟大、光荣、正确的党。在伟大领袖毛主席的无产阶级革命路线指引下，党所领导的革命事业取得了伟大的胜利。但由于我们党在过去长时期内所领导的革命运动是资产阶级民主主义性质的，因此有不少资产阶级，小资产阶级民主主义者参加到革命队伍中来，包括加入无产阶级的先锋队。他们中有许多人接受了马克思列宁主义的教育，经过长期革命斗争的锻炼，已经逐步抛弃了资产阶级世界观，接受或树立了无产阶级的立场和世界观。但也还有少数人受资产阶级思想影响很深而文没有接受党的教育和改造，他们的立场、世界观没有发生变化。社会主义社会存在着资产阶级，它的思想也必然会影响到无产阶级先锋队中某些人，使他们变为资产阶级民主主义者、修正主义者。这些人的世界观总是要在政治问题和思想问题上用各种办法顽强地表现出来，要他们不表现是不可能的。因此，无产阶级政党对于这种要按照资产阶级的面貌来改造党，改造社会的企图，必须进行坚决的斗争。对于犯有错误的同志，我们党历来的方针是“惩前虑后，治病数人”。在当前这场斗争中，我们要继续执行这个方针，耐心地帮助犯有错误的同志，改正错误，以摘好团结，搞好工作。
毛主席说：“我们反对革命队伍中的顽固派，他们的思想不能随变化了的客观情况而前进，在历史上表现为右倾机会主义。这些人看不出矛盾的斗争已将客观过程推向前进了，而他们的认识仍然停正在旧阶段。一切顽固党的思想都有这样的特征。他们的思想离开了社会的实践，他们不能站在社会车轮的前头充在向导的工作，他们只知跟在车子后面然恨车子走得太快了，企图把它向后拉，开倒车。”在社会主义革命的车轮滚滚向前的时候，顽固地要把车子停下来、向后拉的人，总是会有的，过去有，现在有，将来还会有。不肯改悔的走资派不正是从这方面在给我们上课吗？但是，他们总是少数，真理不在他们手里，群众不在他们一边。群众要求革命，翻案不得人心。无产阶级必将战胜资产阶级和一切剥削阶级，社会主义必将战胜资本主义，共产主义一定能够在全世界实现，这个历史发展的总趋势是谁也改变不了的。
```

## 修改后全文

```text
批判修正主义路线
回击右倾翻案风
从资产阶级民主派到走资派
池
恒
伟大领袖毛主席亲自发动和领导的回击右倾翻案风的伟大斗争，正在教育、科技，文艺等上层建筑的各个领域健康地发展，批判的锋芒，直指提出“三项指示为纲”那个党内不肯改悔的走资本主义道路的当权派。这是无产阶级文化大革命的继续和深入，是政治思想战线上无产阶级和资产阶级、社会主义和资本主义、马克思主义和修正主义的又一次大较量。认真地学习毛主席的重要指示，坚决击退这股右倾翻案风，深入地批判那条同毛主席革命路线相对抗的修正主义路线，批判“三项指示为纲”的修正主义纲领，使这场斗争取得更大的胜利，这是摆在全党同志和全国人民面前的一件大事。经过这场斗争，我们的广大干部和群众，必将受到一次深刻的马克思主义、列宁主义、毛泽东思想的教育，进一步提高阶级斗争和路线斗争的觉悟；我国的社会主义革命和建设事业，必将大大地向前推进一步。
革命大辩论的深入发展，向人们提出了一些发人深省的问题：为什么有的人在新民主主义革命时期革过别人的命，到了社会主义革命时期总是同革命唱反调，成了走资本主义道路的当权派？为什么有的走资派受到文化大革命的批判之后，发誓“永不翻案”，可是重新工作没多久就大刮右倾翻案风，对文化大革命又是翻案又是算帐，成了不肯改悔的走资派？为什么不肯改悔的走资派要否认社会主义社会的阶级、阶级矛盾和阶级斗争，反对以阶级斗争为纲，公然抛出“三项指示为纲”的修正主义纲领，同毛主席为我们党制定的基本路线相对抗？针对这些问题，用马克思主义、列宁主义、毛泽东思想作指导，运用阶级分析的方法来部析党内不肯改悔的走资派的阶级立场和世界观，就可以找到这股右倾翻案风的阶级根源和思想根源，可以更好地发挥反面教员的作用，使我们从中得到有益的教训。
一九五九年，毛主席在党的八届八中全会上曾经深刻地指出，党内的右倾机会主义分子从来不是无产阶级革命家，只不过是跑到无产阶级革命队伍里来的资产阶级，小资产阶级的民主派；他们从来不是马克思列宁主义者，只不过是党的同路人。党内不肯改悔的走资派，也正是这样一种人。他们是带着资产阶级民主主义思想来参加无产阶级革命队伍的，他们在组织上入了党，思想上并没有完全入党，甚至完全没有入党。他们在程度不同地接受党的最低纲领即新民主主义革命纲领时，并没有把它同党的最高纲领即社会主义、共产主义的纲领联系起来，他们不懂得也不准备去实践党的最高纲领。也就是说，他们的世界观并不是无产阶级的共产主义世界观，而是一个资产阶级的王国。这种资产阶级立场，世界观又没有在长期的革命斗争中得到改造；当革命从新民主主义革命阶段向社会主义革命阶段转变的时候，他们的思想并没有随着革命的转变而转变。相反，他们的身子虽然进了社会主义社会，思想却还停止在民主革命阶段，这就决定了他们对社会主义革命必然产生抵触甚至反对。资产阶级民主派的立场和世界观，代表资产阶级，就是右倾翻案风的阶级根源和思想根源。
我们党领导的新民主主义革命和社会主义革命，是性质，对象，任务都有本质区别的两个革命阶段。前者发生在半殖民地半封建社会的旧中国，它要解决的主要矛盾，是包括工人、农民，小资产阶级，民族资产阶级在内的人民大众，同帝国主义，封建主义、官僚资本主义的矛盾。所以它的性质是反帝反封建的资产阶级民主革命，它的任务，是在无产阶级领导下，推翻帝国主义、封建地主阶级和官僚买办资产阶级在中国的统治，把革命引向社会主义。随着新民主主义革命的胜利，我国的社会性质和主要矛盾已经发生变化。无产阶级同资产阶级的矛盾成了国内的主要矛盾。这个主要矛盾，不仅存在于社会上，面且反映到党内。我们所进行的社会主义革命，就是无产阶级反对资产阶级和一切剥削阶级的革命。革命的锋芒主要是指向资产阶级，指向党内走资本主义道路的当权派。它的任务是要用无产阶级专政代替资产阶级专政，用社会主义战胜资本主义，并在长期的阶级斗争中逐步造成资产阶级既不能存在又不能产生的条件，最后消灭阶级，实现共产主义。一九四九年中华人民共和国成立，标志着社会主义革命阶段的开始。在毛主席革命路线的指引下，二十多年来，社会主义革命已经取得了伟大的胜利，但是还远远没有完结，还在继续深入发展。革命转变了，向前发展了，要求人们的思想也要随着革命的转变而转变，随着革命的发展而发展。如果思想还停止在旧阶段，用资产阶级民主派的立场和世界观来认识和对待社会主义革命，那就会代表资产阶级，就会成为走资派，成为社会主义革命的对象。
我国新民主主义革命胜利以后，在毛主席革命路线的指引下，广大工人、贫下中农，广大党员、干部没有停顿，而是沿着社会主义道路继续前进。但是党内有一些人的思想还停止在民主革命阶段，不想沿着社会主义道路继续前进，继续革命了。不前进，就会倒退，不革命，就会搞复辟，不走社会主义道路，必然要走资本主义道路。列宁曾经指出：“有些人象小私有者一样看待对资本家的胜利，他们说：‘资本家已经捞了一把，现在该轮到我了。’”党内不肯改悔的走资派不也是这样吗？他们害怕社会主义革命革到自已头上，触动私有制，触动他们所喜欢的资产阶级法权，触动他们要维护的传统观念，触动他们的资产阶级立场和世界观，成了资产阶级的代表。社会主义革命越深入，他们同革命的矛盾，同坚持继续革命的工人，贫下中农的矛盾，也就越尖锐。在社会主义革命的进程中，他们后退了，反对革命了。就是那个作为右倾翻案风“风源”的不肯改悔的走资派，曾经反对农业合作化和人民公社化，支持包产到户，鼓吹“不管白猫黑猫，捉住老鼠就是好猫”的谬论，后来又反对文化大革命，镇压革命群众运动，现在文闹翻案、搞复辟。从资产阶级民主派到走资本主义道路的当权派，从民主革命时期党的同路人到社会主义时期的反对派，复辟派，从思想停上在资产阶级民主革命阶段到搞修正主义，这不正是不肯改悔的走资涨所实际走过的道路吗？
历史的经验和现实的斗争都说明，在社会主义革命时期，思想还停止在资产阶级民主革命阶段，就会搞修正主义，推行修正主义路线。毛主席指出：“修正主义是一种资产阶级思想。修正主义者抹杀社会主义和资本主义的区别，抹杀无产阶级专致和资产阶级专政的区别。他们所主张的，在实际上并不是社会主义路线，而是资本主义路线。”从思想体系和阶级根源来看，资产阶级的立场，世界观和修正主义是一致的。机会主义，修正主义是工人运动中代表资产阶级利益的派别和思想，它的特征是叛卖无产阶级的根本利益，向资产阶级投降。修正主义者总是站在资产阶级立场上，鼓吹阶级调和论，阶级斗争熄灭论和唯生产力论，总是用这些修正主义谬论，来反对无产阶级对资产阶级的阶级斗争，反对无产阶级专政。从伯恩施坦、考茨基到托洛茨基、布哈林，从赫鲁晓夫、勃列日涅夫到刘少奇、林彪，都是这么干的。党内不肯改悔的走资派，也是这样。他迫不及待地抛出“三项指示为纲”的修正主义纲领，鼓吹阶级斗争熄灭论和唯生产力论，以此来否定党的基本路线，同马克思主义，列宁主义、毛泽东思想关于阶级斗争和无产阶级专政的理论相对抗；并用它来于扰，破坏毛主席亲自发动和领导的无产阶级专政理论的学习运动和评论《水浒》；用它在各个领域推行修正主义路线。去年在教育，科技、文艺以及其他战线出现的反对毛主席革命路线，反对文化大革命和社会主义新生事物的各种奇谈怪论，就是根据“三项指示为纲”这个修正主义纲领派生出来的。思想停止在民主革命阶段，否认社会主义时期的阶级，阶级矛盾和阶级斗争，就必然要搞修正主义。党内不肯改悔的走资派刮起的右倾翻案风，又一次说明了这一点。
毛主席说：“杆么‘三项指示为纲”，安定团绪不是不要阶级斗争，阶级斗争是纳，其余舞是目。”这是对“三项指示为纲”的修正主义纲领的深刻批判。二十多年来，我们所进行的社会主义革命已经取得了伟大的胜利，但是，阶级斗争并没有熄灭。失败的阶级，人还在，阶级还在，还要挣扎，时刻梦想着复辟，资产阶级和小资产阶级还存在，大量未改造好的知识分子还存在；小生产的习惯势力和传统影响还存在，还在产生资产阶级和资本主义。所有这些不是人们都看见了的事实吗：资产阶级在党内的代理人，刘少奇，林彪反党集团妄图颠覆无产阶级专政、复辟资本主义的阴谋活动，不是使人们感到惊心动魄吗！林彪一类党内新的资产阶级分子的产生，不是给我们以深刻的教育吗！清华大学的同志说得好：走资派还在走，投降派确实有。在这种情况下，能说阶级斗争熄灭了吗？党内不肯改悔的走资派抛出“三项指示为纲”，鼓吹阶级斗争熄灭论和唯生产力论，并不是要真正熄灭阶级斗争，他们是要扑灾无产阶级对资产阶级的斗争，而代表资产阶级向无产阶级进行斗争。他们要安定团结、发展生产是假，不要无产阶级专政，而要资本主义复辟才是真的。他们的修正主义路线是破坏安定团结，破坏社会主义生产的。这就从反面告诉我们，必须坚持以阶级斗争为纲，从政治、经济、思想文化各个方面，加强无产阶级对资产阶级的全面专政，不断地把社会主义革命推向前进。
民主革命胜利以后，是把革命停止在旧阶段不再前进，还是坚持搞社会主义革命，为最终实现共产主义而奋斗，也就是说要不要坚持不解地革资产阶级的命，这是无产阶级革命派和资产阶级民主派、马克思主义者和修正主义者的一个根本分歧。社会主义时期党内两条路线的斗争，正是围绕着这个问题展开的。修正主义路线的头子因为他们自己代表资产阶级，都反对革资产阶级的命，特别反对革党内资产阶级的命。党内不肯改悔的走资派为什么对文化大革命那么反感？为什么把文化大革命中涌现出来的社会主义新生事物，看成眼中钉、肉中刺，于方百计地想把它们“整”掉，而对文化大革命批判过的资本主义、修正主义的黑货，又那么舍不得，总想把它们恢复过来？就是因为“无产阶级文化大革命，实质上是在社会主义条件下，无产阶级反对资产阶级和一切剥削阶级的政治大革命”，这场大革命摧毁了刘少奇、林彪两个资产阶级司令部，批判了他们的修正主义路线，整了党内走资派，革了党内资产阶级的命，批判了资产阶级和一切剥削阶级的意识形态，对不适应社会主义经济基础的教育、文艺及其他上层建筑进行了改革。所有这些，同党内不肯改梅的走资派所代表的资产阶级利益，所顽固坚持的资产阶级立场和世界观是相对抗的，同他们极力要走的那条资本主义道路是背道而驰的。这就决定了他们必然要充当无产阶级文化大革命的反对派。人们还清楚地记得，就是那个带头刮右倾翻案风的人，在文化大革命初期，同刘少奇一起推行资产阶级反动路线，企图把轰轰烈烈的革命群众运动镇压下去。然而，这种倒行逆施并没有能够扭转革命车轮的前进，文化大革命和批林批孔运动取得了伟大的胜利。但不肯改悔的走资派并没有从中吸取教训，仍然代表资产阶级，用修正主义的眼光来看待这场大革命，把文化大革命以后的大好形势看成一团漆黑，总认为这也不行，那也不好，不翻案，不复辟就不舒服。“只要人家说你复辟了，你的工作就于好了”。这个自白把不肯改悔的走资派代表资产阶级搞复辟的反动立场暴露得清清楚楚了。他们的这次表演，又一次证明了毛主席的英明论断：革命的谁胜谁负，要在一个很长的历史时期内才能解决。如果弄得不好，资本主义复辟将是随时可能的。全体党员，全国人民，不要以为有一二次，三四次文化大革命，就可以太平无事了。千万注就，决不可丧失惕。
要把社会主义革命推向前进，就要在无产阶级专政下，对社会主义社会各方面存在的资产阶级法权加以限制。这也是思想停止在民主革命阶段的人不能接受而要加以反对的。社会生义社会还存在旧社会遗留下来的痕迹，存在着资产阶级法权，存在着三大差别。这些东西是产生资产阶级和资本主义的土壤和条件。限制资产阶级法权，逐步地铲除和消灭旧社会遗留下来的痕迹，这是社会主义时期一项长期的任务。社会主义革命越深入，就越要把这个任务提出来，越要着手这方面的工作。毛主席指出：“我国现在实行的是商品制度，工资制度也不平等，有八级工资制，等等。这只能在无产阶级专政下加以限制。所以，林彪一类如上台，搞资本主义制度很容易。因此，要多看点马列主义的书。”毛主席的指示反映了无产阶级和革命人民要把社会主义革命推向前进的愿望和要求，也引起了思想停止在民主革命阶段的人的害怕和抵触。资产阶级法权正是那些要阻止革命前进的人的命根子，他们所欣赏，所追求的就是这一块资产阶级法权，他们总是把资产阶级法权看成天经地义、不能触动的，总想把它强化和扩大。当革命革到这些人的头上，要求限制他们维护的那部分资产阶级法权时，他们就要跳出来反对。不肯改悔的走资派为什么那样仇视从各个方面限制了资产阶级法权的新生事物？为什么对批判物质刺激、知识私有等资产阶级法权思想提出种种责难？为什么那样害怕提出限制资产阶级法权的问题，并千方百计加以反对？为什么竟然明自张胆地同毛主席的指示唱反调，胡说“限制资产阶级法权，也要有一个物质基础，没有，怎么限制？”就是因为他代表资产阶级，他要维护并强化资产阶级法权，维护并扩大资产阶级赖以产生和存在的基础。这就进一步暴露了不肯改悔的走资派的资产阶级立场和世界观
由于思想停止在民主革命阶段，因而同社会主义革命相抵触甚至相反对，这是二十多年来我们党内反复出现的一种历史现象。例如，一九五三年我们党决定实行统购统销政策，这是进行社会主义革命和社会主义建设的一个重要步骤。当时党内就有人跳出来坚决反对，他们虽然顶着共产党员的称号，却成了城乡资本主义势力反对社会主义革命的代言人。在农业合作化时期，刘少奇一伙大批砍掉合作社，而后文当算帐派，刮起一阵所谓合作社没有优越性的小台风。他们为什么会逆社会主义革命的伟大潮流而动呢？他们想的做的为什么同儿亿农民想的做的，是如此不同甚至相反呢？根本问题就是他们的思想还停止在民主革命阶段，他们总是站在资产阶级立场上为少数人服务。正象毛主席所指出的：“他们老是站在资产阶级、1农、或者具有资本主义自发倾向的富裕中农的立场上替较少的人打主意，而没有站在工人阶级的立场上替整个国家和全体人民打主意。”又如，一九五七年资产阶级右派利用党的整风，向无产阶级发动猖狂进攻的时候，党内也有人主张资产阶级的纲领。他们同社会上的资产阶级右派互相呼应，要求实行资产阶级的“民主”“自由”和“平等”，反对党的领导，尤其反对党对教育、科学的领导，鼓欧什么“外行不能领导内行”，“教授治校”等口号。他们实际上是主张走资本主义道路，反对走社会主义道路，反对无产阶级专政。一九五九年彭德怀右倾机会主义反对党的总路线，否定大跃进和人民公社，再一次暴露了一些人的资产阶级民主派的本来面目。他们要在社会主义革命时期推行资本主义的纲领和口号，这就不能不被社会主义革命的潮流所淘汰。
在社会主义革命时期，共产党内还会有一些人思想停止在民主革命阶段，用资产阶级的立场、世界观看待事物，这种现象并不奇怪。我们的党是伟大、光荣、正确的党。在伟大领袖毛主席的无产阶级革命路线指引下，党所领导的革命事业取得了伟大的胜利。但由于我们党在过去长时期内所领导的革命运动是资产阶级民主主义性质的，因此有不少资产阶级，小资产阶级民主主义者参加到革命队伍中来，包括加入无产阶级的先锋队。他们中有许多人接受了马克思列宁主义的教育，经过长期革命斗争的锻炼，已经逐步抛弃了资产阶级世界观，接受或树立了无产阶级的立场和世界观。但也还有少数人受资产阶级思想影响很深而文没有接受党的教育和改造，他们的立场、世界观没有发生变化。社会主义社会存在着资产阶级，它的思想也必然会影响到无产阶级先锋队中某些人，使他们变为资产阶级民主主义者、修正主义者。这些人的世界观总是要在政治问题和思想问题上用各种办法顽强地表现出来，要他们不表现是不可能的。因此，无产阶级政党对于这种要按照资产阶级的面貌来改造党，改造社会的企图，必须进行坚决的斗争。对于犯有错误的同志，我们党历来的方针是“惩前虑后，治病数人”。在当前这场斗争中，我们要继续执行这个方针，耐心地帮助犯有错误的同志，改正错误，以摘好团结，搞好工作。
毛主席说：“我们反对革命队伍中的顽固派，他们的思想不能随变化了的客观情况而前进，在历史上表现为右倾机会主义。这些人看不出矛盾的斗争已将客观过程推向前进了，而他们的认识仍然停正在旧阶段。一切顽固党的思想都有这样的特征。他们的思想离开了社会的实践，他们不能站在社会车轮的前头充在向导的工作，他们只知跟在车子后面然恨车子走得太快了，企图把它向后拉，开倒车。”在社会主义革命的车轮滚滚向前的时候，顽固地要把车子停下来、向后拉的人，总是会有的，过去有，现在有，将来还会有。不肯改悔的走资派不正是从这方面在给我们上课吗？但是，他们总是少数，真理不在他们手里，群众不在他们一边。群众要求革命，翻案不得人心。无产阶级必将战胜资产阶级和一切剥削阶级，社会主义必将战胜资本主义，共产主义一定能够在全世界实现，这个历史发展的总趋势是谁也改变不了的。
```
- BHA 预览：https://vomebook-bha-search.hf.space/?preview=2%3A10%3A0530a4cc57%3A5382c50c-a47e-4f7f-bb62-396b1033f322